### PR TITLE
Full-screen mode via CSS (closes #15)

### DIFF
--- a/views/shared/javascripts/theme/default/style.css
+++ b/views/shared/javascripts/theme/default/style.css
@@ -1,3 +1,7 @@
+div#wrap {
+    width: 90%; 
+}
+
 div.olMap {
     z-index: 0;
     padding: 0px!important;


### PR DESCRIPTION
This css hack works for the deco theme https://github.com/ebellempire/Deco
