### PR TITLE
Transcribe add label

### DIFF
--- a/views/shared/index/transcribe.php
+++ b/views/shared/index/transcribe.php
@@ -381,7 +381,9 @@ jQuery(document).ready(function() {
 <div id="scripto-talk">
     <?php if ($this->doc->canEditTalkPage()): ?>
     <div id="scripto-talk-edit" style="display: none;">
-        <div><?php echo $this->formTextarea('scripto-talk-page-wikitext', $this->doc->getTalkPageWikitext(), array('cols' => '76', 'rows' => '16')); ?></div>
+        <div>
+            <label for="scripto-talk-page-wikitext"><?php echo __('Edit Discussion'); ?></label>
+            <?php echo $this->formTextarea('scripto-talk-page-wikitext', $this->doc->getTalkPageWikitext(), array('cols' => '76', 'rows' => '16')); ?></div>
         <div>
             <?php echo $this->formButton('scripto-talk-page-edit', __('Edit discussion'), array('style' => 'display:inline; float:none;')); ?> 
         </div>

--- a/views/shared/index/transcribe.php
+++ b/views/shared/index/transcribe.php
@@ -353,7 +353,10 @@ jQuery(document).ready(function() {
 <div id="scripto-transcription">
     <?php if ($this->doc->canEditTranscriptionPage()): ?>
     <div id="scripto-transcription-edit" style="display: none;">
-        <div><?php echo $this->formTextarea('scripto-transcription-page-wikitext', $this->doc->getTranscriptionPageWikitext(), array('cols' => '76', 'rows' => '16')); ?></div>
+        <div>
+            <label for="scripto-transcription-page-wikitext"><?php echo __('Transcription'); ?></label>
+            <?php echo $this->formTextarea('scripto-transcription-page-wikitext', $this->doc->getTranscriptionPageWikitext(), array('cols' => '76', 'rows' => '16')); ?>
+        </div>
         <div>
             <?php echo $this->formButton('scripto-transcription-page-edit', __('Edit transcription'), array('style' => 'display:inline; float:none;')); ?> 
         </div>


### PR DESCRIPTION
Hi all, 

In order to make the page more accessible for users of assistive technology, I've added labels for the transcription and discussion text areas. 

For more information about this, see section 2.4.6 of the W3C Web Content Accessibility Guidelines (http://www.w3.org/TR/2008/REC-WCAG20-20081211/#navigation-mechanisms-descriptive).

If you think the labels are redundant or unnecessary for visual users, one option is to hide the labels by positioning them offscreen. That way the presentation of your page will not change, but the labels will still be present for assistive technologies. 
