### PR TITLE
Removed potentially extraneous jquery import.

### DIFF
--- a/views/shared/index/transcribe.php
+++ b/views/shared/index/transcribe.php
@@ -4,7 +4,6 @@ $head = array('title' => html_escape(implode(' | ', $titleArray)));
 echo head($head);
 ?>
 <?php echo js_tag('OpenLayers'); ?>
-<?php echo js_tag('jquery', 'javascripts/vendor'); ?>
 <script type="text/javascript">
 jQuery(document).ready(function() {
     


### PR DESCRIPTION
Hi all, 

Is is necessary to import jquery here? I'm creating a plugin to load the [markitup editor](https://github.com/markitup/1.x) on the transcription field, but loading jQuery here prevents other plugins from adding plugins to the jquery object. 

I'd imagine that in 99% of the cases, jQuery is loaded by default unless a developer specifically disables it by passing false to head_js.

Alternatively, could you add this by implementing the 'public_head' hook and using queue_js_file()? I'm assuming that hook execution order is deterministic here but I haven't taken the time to investigate this fully. Assuming it is, we could ensure that our markitup 'public_head' hook runs after Scripto.  

Thanks, 
-Adam
